### PR TITLE
@ #58 | _id_deprecated, _op should be deleted from provisioner options

### DIFF
--- a/lib/teracy-dev-core/config/provisioners.rb
+++ b/lib/teracy-dev-core/config/provisioners.rb
@@ -30,7 +30,7 @@ module TeracyDevCore
 
           options = provisioner_settings.dup
 
-          ["_id", "type", "name", "enabled", "run", "preserve_order", "weight"].each do |key|
+          ["_id", "_id_deprecated", "_op", "type", "name", "enabled", "run", "preserve_order", "weight"].each do |key|
             options.delete(key)
           end
 


### PR DESCRIPTION
connect #58 
please check this PR! Thank you